### PR TITLE
[Bugfix] Pending Other Signers

### DIFF
--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -312,7 +312,7 @@ export const searchForWaitingOnOthersDocuments = async (email) => {
     .get()
     .then(function (querySnapshot) {
       querySnapshot.forEach(function (doc) {
-        const { docRef, emails, email, signedTime, requestedTime, signedBy, lastUpdated } = doc.data();
+        const { docRef, emails, email: preparedBy, signedTime, requestedTime, signedBy, lastUpdated } = doc.data();
         if (signedBy.includes(email)) {
           const docId = doc.id;
           const remainingToSign = emails.filter(


### PR DESCRIPTION
Method that made an API call to Firebase was broken (i.e. not returning anything) due to de-structuring clash, but I've corrected it in this PR:

![image](https://user-images.githubusercontent.com/16601729/138366320-9c1dba3b-769e-49d0-af29-851c49845a3c.png)

Note how `email` was already defined in the function signature:

https://github.com/PDFTron/pdftron-sign-app/blob/ee1f11b27f74ea39972d1a75a37ae2dfdb38b342/src/firebase/firebase.js#L302