### PR TITLE
Webviewer version 11.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo is designed to help to get started in creating your own signing workfl
 
 - Ability to add date fields
 - Ability to see when the document was requested and signed
-- Update WebViewer to 10.0
+- Update WebViewer to 11.8.0
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@pdftron/webviewer": "^10.0.0",
+    "@pdftron/webviewer": "^11.8.0",
     "@reach/router": "^1.3.3",
     "@reduxjs/toolkit": "^1.3.6",
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/components/PrepareDocument/PrepareDocument.js
+++ b/src/components/PrepareDocument/PrepareDocument.js
@@ -49,19 +49,17 @@ const PrepareDocument = () => {
           'searchButton',
           'menuButton',
         ],
+        fullAPI: true,
       },
       viewer.current,
     ).then(instance => {
-      const { iframeWindow } = instance.UI;
-
       // select only the view group
       instance.UI.setToolbarGroup('toolbarGroup-View');
 
       setInstance(instance);
 
-      const iframeDoc = iframeWindow.document.body;
-      iframeDoc.addEventListener('dragover', dragOver);
-      iframeDoc.addEventListener('drop', e => {
+      viewer.current.addEventListener('dragover', dragOver);
+      viewer.current.addEventListener('drop', e => {
         drop(e, instance);
       });
 
@@ -284,11 +282,10 @@ const PrepareDocument = () => {
   };
 
   const drop = (e, instance) => {
-    const { docViewer } = instance;
-    const scrollElement = docViewer.getScrollViewElement();
+    const scrollElement = instance.Core.documentViewer.getScrollViewElement();
     const scrollLeft = scrollElement.scrollLeft || 0;
     const scrollTop = scrollElement.scrollTop || 0;
-    setDropPoint({ x: e.pageX + scrollLeft, y: e.pageY + scrollTop });
+    setDropPoint({ x: e.offsetX + scrollLeft, y: e.offsetY + scrollTop });
     e.preventDefault();
     return false;
   };


### PR DESCRIPTION
Fixed the following issues:

- Updated the version on package.json and readme.
- The app breaks on accessing iframeWindow, when WebViewer v11 is used.
- When loading a file in the webviewer, it freezes.
- The drop event:
   A. Drop a signature is breaking. The call of getScrollViewElement is breaking app as it being called from docViewer.
   B. Drop a signature offset is incorrect.

For more information of the fixes, please refer to https://apryse.atlassian.net/browse/AS-177.